### PR TITLE
Fix install bug

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -10,6 +10,7 @@ fields:
     target:
       type: environment
       name: SETUP_MODE
+      service: operator
     required: false
 
   - id: builder-proposals


### PR DESCRIPTION
If the service to which the `SETUP_MODE` env is not defined, the dappmanager tries to set this env to the `<pkg-name>` service, in this case, `ssv-holesky.dnp.dappnode.eth` but in this package there are only 2 services, `operator` and `dkg`