### PR TITLE
Support 'publicKey' field in private key file

### DIFF
--- a/dkg/entrypoint.sh
+++ b/dkg/entrypoint.sh
@@ -51,6 +51,11 @@ fetch_operator_id_from_api() {
 
     PUBLIC_KEY=$(jq -r '.pubKey' ${PRIVATE_KEY_FILE})
 
+    # If the PUBLIC_KEY is empty, try extracting using the '.publicKey' field (for previous SSV versions)
+    if [ -z "$PUBLIC_KEY" ] || [ "$PUBLIC_KEY" = "null" ]; then
+        PUBLIC_KEY=$(jq -r '.publicKey' "${PRIVATE_KEY_FILE}")
+    fi
+
     # Fetch the operator ID using the public key (retry 50 times with a delay of 10mins)
     RESPONSE=$(curl --retry 50 --retry-delay 600 "https://api.ssv.network/api/v4/${NETWORK}/operators/public_key/${PUBLIC_KEY}")
 

--- a/operator/entrypoint.sh
+++ b/operator/entrypoint.sh
@@ -99,6 +99,11 @@ handle_private_key() {
 post_pubkey_to_dappmanager() {
   PUBLIC_KEY=$(jq -r '.pubKey' ${PRIVATE_KEY_FILE})
 
+  # If the PUBLIC_KEY is empty, try extracting using the '.publicKey' field (for previous SSV versions)
+  if [ -z "$PUBLIC_KEY" ] || [ "$PUBLIC_KEY" = "null" ]; then
+    PUBLIC_KEY=$(jq -r '.publicKey' "${PRIVATE_KEY_FILE}")
+  fi
+
   curl --connect-timeout 5 \
     --max-time 10 \
     --silent \


### PR DESCRIPTION
Previous SSV versions generated the private key file with `publicKey` field instead of `pubKey`. This PR aims to give support to those private key files generated in previous SSV versions