### PR TITLE
Follow good practices in entrypoints

### DIFF
--- a/dkg/entrypoint.sh
+++ b/dkg/entrypoint.sh
@@ -3,7 +3,6 @@
 OPERATOR_CONFIG_DIR=${OPERATOR_DATA_DIR}/config
 DKG_LOGS_DIR=${DKG_DATA_DIR}/logs
 DKG_OUTPUT_DIR=${DKG_DATA_DIR}/output
-DKG_DB_PATH=${DKG_DATA_DIR}/db
 DKG_CERT_DIR=${DKG_DATA_DIR}/ssl
 
 PRIVATE_KEY_FILE=${OPERATOR_CONFIG_DIR}/encrypted_private_key.json
@@ -16,14 +15,14 @@ CERT_FILE="$DKG_CERT_DIR/tls.crt"
 KEY_FILE="$DKG_CERT_DIR/tls.key"
 
 create_directories() {
-    mkdir -p ${DKG_CONFIG_DIR} ${DKG_LOGS_DIR} ${DKG_OUTPUT_DIR}
+    mkdir -p "${DKG_CONFIG_DIR}" "${DKG_LOGS_DIR}" "${DKG_OUTPUT_DIR}"
 }
 
 wait_for_private_key() {
     echo "[INFO] Waiting for the operator service to create the private key file..."
     while [ ! -f "${PRIVATE_KEY_FILE}" ]; do
         echo "[INFO] Waiting for ${PRIVATE_KEY_FILE} to be created..."
-        inotifywait -e create -qq $(dirname "${PRIVATE_KEY_FILE}")
+        inotifywait -e create -qq "$(dirname "${PRIVATE_KEY_FILE}")"
     done
 
     echo "[INFO] Private key file found."
@@ -39,21 +38,21 @@ get_operator_id() {
 
         # Read operator ID from the file if it exists and is not empty
         if [ -f "${OPERATOR_ID_FILE}" ] && [ -s "${OPERATOR_ID_FILE}" ]; then
-            OPERATOR_ID=$(cat ${OPERATOR_ID_FILE})
+            OPERATOR_ID=$(cat "${OPERATOR_ID_FILE}")
             echo "[INFO] Using OPERATOR_ID from the file: ${OPERATOR_ID}"
         else
             fetch_operator_id_from_api
         fi
     else
         echo "[INFO] Using provided OPERATOR_ID: ${OPERATOR_ID}"
-        echo "${OPERATOR_ID}" >${OPERATOR_ID_FILE}
+        echo "${OPERATOR_ID}" >"${OPERATOR_ID_FILE}"
     fi
 }
 
 fetch_operator_id_from_api() {
     echo "[INFO] OPERATOR_ID not provided. Fetching OPERATOR_ID from the API..."
 
-    PUBLIC_KEY=$(jq -r '.pubKey' ${PRIVATE_KEY_FILE})
+    PUBLIC_KEY=$(jq -r '.pubKey' "${PRIVATE_KEY_FILE}")
 
     # If the PUBLIC_KEY is empty, try extracting using the '.publicKey' field (for previous SSV versions)
     if [ -z "$PUBLIC_KEY" ] || [ "$PUBLIC_KEY" = "null" ]; then
@@ -73,38 +72,38 @@ fetch_operator_id_from_api() {
         exit 0
     else
         echo "[INFO] Successfully fetched OPERATOR_ID: ${OPERATOR_ID}"
-        echo "${OPERATOR_ID}" >${OPERATOR_ID_FILE}
+        echo "${OPERATOR_ID}" >"${OPERATOR_ID_FILE}"
     fi
 }
 
 generate_tls_cert() {
     echo "[INFO] Generating TLS certificates..."
-    
+
     mkdir -p "$DKG_CERT_DIR"
 
     # Generate a self-signed SSL certificate only if it doesn't exist
     if [ ! -f "$CERT_FILE" ] || [ ! -f "$KEY_FILE" ]; then
-      echo "[INFO] Certificate or key file not found. Generating new SSL certificate and key."
-      openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
-        -keyout "$KEY_FILE" -out "$CERT_FILE" \
-        -subj "/C=IL/ST=Tel Aviv/L=Tel Aviv/O=Coin-Dash Ltd/CN=*.ssvlabs.io"
+        echo "[INFO] Certificate or key file not found. Generating new SSL certificate and key."
+        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+            -keyout "$KEY_FILE" -out "$CERT_FILE" \
+            -subj "/C=IL/ST=Tel Aviv/L=Tel Aviv/O=Coin-Dash Ltd/CN=*.ssvlabs.io"
     else
-      echo "[INFO] Existing SSL certificate and key found. Using them."
+        echo "[INFO] Existing SSL certificate and key found. Using them."
     fi
 }
 
 start_dkg() {
     exec /bin/ssv-dkg start-operator \
-        --operatorID ${OPERATOR_ID} \
-        --configPath ${DKG_CONFIG_FILE} \
-        --logFilePath ${DKG_LOG_FILE} \
-        --logLevel ${LOG_LEVEL} \
-        --outputPath ${DKG_OUTPUT_DIR} \
-        --port ${DKG_PORT} \
-        --privKey ${PRIVATE_KEY_FILE} \
-        --privKeyPassword ${PRIVATE_KEY_PASSWORD_FILE} \
-        --serverTLSCertPath ${CERT_FILE} \
-        --serverTLSKeyPath ${KEY_FILE}
+        --operatorID "${OPERATOR_ID}" \
+        --configPath "${DKG_CONFIG_FILE}" \
+        --logFilePath "${DKG_LOG_FILE}" \
+        --logLevel "${LOG_LEVEL}" \
+        --outputPath "${DKG_OUTPUT_DIR}" \
+        --port "${DKG_PORT}" \
+        --privKey "${PRIVATE_KEY_FILE}" \
+        --privKeyPassword "${PRIVATE_KEY_PASSWORD_FILE}" \
+        --serverTLSCertPath "${CERT_FILE}" \
+        --serverTLSKeyPath "${KEY_FILE}"
 }
 
 main() {

--- a/operator/entrypoint.sh
+++ b/operator/entrypoint.sh
@@ -14,7 +14,7 @@ DEFAULT_PRIVATE_KEY_FILE=/encrypted_private_key.json
 RAW_NODE_YML_CONFIG_FILE=${NODE_CONFIG_DIR}/raw-node-config.yml
 
 create_directories() {
-  mkdir -p ${OPERATOR_CONFIG_DIR} ${OPERATOR_DB_DIR} ${OPERATOR_LOGS_DIR}
+  mkdir -p "${OPERATOR_CONFIG_DIR}" "${OPERATOR_DB_DIR}" "${OPERATOR_LOGS_DIR}"
 }
 
 assign_execution_endpoint() {
@@ -97,7 +97,7 @@ handle_private_key() {
 }
 
 post_pubkey_to_dappmanager() {
-  PUBLIC_KEY=$(jq -r '.pubKey' ${PRIVATE_KEY_FILE})
+  PUBLIC_KEY=$(jq -r '.pubKey' "${PRIVATE_KEY_FILE}")
 
   # If the PUBLIC_KEY is empty, try extracting using the '.publicKey' field (for previous SSV versions)
   if [ -z "$PUBLIC_KEY" ] || [ "$PUBLIC_KEY" = "null" ]; then
@@ -149,17 +149,18 @@ create_operator_config() {
 start_operator() {
   echo "[INFO] Starting SSV operator..."
 
-  /go/bin/ssvnode start-node --config ${NODE_CONFIG_FILE} ${EXTRA_OPTS} &
+  /go/bin/ssvnode start-node --config "${NODE_CONFIG_FILE}" "${EXTRA_OPTS}" &
 
   wait $!
   EXIT_STATUS=$?
 
   # Backup restoring causes the operator to find a mismatch in the DB
-  if [ $EXIT_STATUS -ne 0 ] && grep -q "operator private key is not matching the one encrypted the storage" ${NODE_LOG_FILE}; then
+  if [ $EXIT_STATUS -ne 0 ] && grep -q "operator private key is not matching the one encrypted the storage" "${NODE_LOG_FILE}"; then
     echo "[WARN] Detected private key mismatch, probably due to backup restoring. Removing DB and retrying..."
-    rm -rf ${OPERATOR_DB_DIR}/*
+    # Added :? to prevent accidental deletion of root directory (if $OPERATOR_DB_DIR is empty or unset)
+    rm -rf "${OPERATOR_DB_DIR:?}"/*
 
-    exec /go/bin/ssvnode start-node --config ${NODE_CONFIG_FILE} ${EXTRA_OPTS}
+    exec /go/bin/ssvnode start-node --config "${NODE_CONFIG_FILE}" "${EXTRA_OPTS}"
   else
     exit $EXIT_STATUS
   fi


### PR DESCRIPTION
1. Prevented globbing and word splitting
2. Removed unused vars
3. Prevented `rm` command from deleting `/*` in case `OPERATOR_DB_DIR` is unset